### PR TITLE
service: created for self-managed auto-renewal certificate

### DIFF
--- a/cmd/renew.go
+++ b/cmd/renew.go
@@ -84,7 +84,7 @@ func renew(cmd *cobra.Command, args []string) {
 	}
 
 	// register the account and accept tos
-	if err := acmeClient.RegisterAccount(acceptTOS); err != nil {
+	if err := acmeClient.RegisterAccount(etcdClient, acceptTOS); err != nil {
 		if err == legoetcd.ErrMustAcceptTOS {
 			log.Fatalf("Please re-run with --accept-tos to indicate you accept Let's encrypt terms of service.")
 		}
@@ -92,18 +92,18 @@ func renew(cmd *cobra.Command, args []string) {
 	}
 
 	// load the certificate
-	cert, err := acmeClient.LoadCert(domains)
+	cert, err := legoetcd.LoadCert(etcdClient, domains)
 	if err != nil {
 		log.Fatalf("error load the certificate from etcd: %s", err)
 	}
 
 	// Renew the certificate
-	if err := cert.Renew(!noBundle); err != nil {
+	if err := cert.Renew(acmeClient, !noBundle); err != nil {
 		log.Fatalf("error renewing the certificate: %s", err)
 	}
 
 	// save the certificate
-	if err := cert.Save(pem); err != nil {
+	if err := cert.Save(etcdClient, pem); err != nil {
 		log.Fatalf("error saving the certificate: %s", err)
 	}
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -71,7 +71,7 @@ func run(cmd *cobra.Command, args []string) {
 	}
 
 	// register the account and accept tos
-	if err := acmeClient.RegisterAccount(acceptTOS); err != nil {
+	if err := acmeClient.RegisterAccount(etcdClient, acceptTOS); err != nil {
 		if err == legoetcd.ErrMustAcceptTOS {
 			log.Fatalf("Please re-run with --accept-tos to indicate you accept Let's encrypt terms of service.")
 		}
@@ -88,7 +88,7 @@ func run(cmd *cobra.Command, args []string) {
 	}
 
 	// save the certificate
-	if err := cert.Save(pem); err != nil {
+	if err := cert.Save(etcdClient, pem); err != nil {
 		log.Fatalf("error saving the certificate: %s", err)
 	}
 }

--- a/legoetcd/cert.go
+++ b/legoetcd/cert.go
@@ -144,6 +144,11 @@ func (c *Cert) ExpiresIn() (time.Duration, error) {
 	return expTime.Sub(time.Now()), nil
 }
 
+// PEM returns this certificate PEM-encoded.
+func (c *Cert) PEM() []byte {
+	return bytes.Join([][]byte{c.Cert.Certificate, c.Cert.PrivateKey}, nil)
+}
+
 // Save saves the certificate to etcd.
 func (c *Cert) Save(pem bool) error {
 	if err := c.saveCert(); err != nil {
@@ -258,7 +263,7 @@ func (c *Cert) saveMeta() error {
 
 func (c *Cert) savePem() error {
 	// combine the cert/key
-	pem := bytes.Join([][]byte{c.Cert.Certificate, c.Cert.PrivateKey}, nil)
+	pem := c.PEM()
 	// create a new keys API
 	kapi := client.NewKeysAPI(c.client.ETCD)
 	// save it to etcd

--- a/legoetcd/service/lock.go
+++ b/legoetcd/service/lock.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
+)
+
+// ErrLockExists is returned if unable to grab a lock.
+var ErrLockExists = errors.New("was unable to grab a lock, lock already exists")
+
+// Lock places a lock at the provided path in etcd.
+func (s *Service) Lock(c client.Client, path string) error {
+	// create a new keys API
+	kapi := client.NewKeysAPI(c)
+	// save it to etcd
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Second)
+	if _, err := kapi.Set(ctx, path, s.lockContents(), &client.SetOptions{PrevExist: client.PrevNoExist, TTL: 1 * time.Hour}); err != nil {
+		if err.(client.Error).Code == client.ErrorCodeNodeExist {
+			return ErrLockExists
+		}
+		return err
+	}
+	cancelFunc()
+	return nil
+}
+
+// Unlock removes the lock at the provided path from etcd
+func (s *Service) Unlock(c client.Client, path string) error {
+	// create a new keys API
+	kapi := client.NewKeysAPI(c)
+	// save it to etcd
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Second)
+	if _, err := kapi.Delete(ctx, path, &client.DeleteOptions{PrevValue: s.lockContents()}); err != nil {
+		return err
+	}
+	cancelFunc()
+	return nil
+}
+
+// WaitForLockDeletion is a blocking call that will wait until the lock is
+// unlocked.
+func (s *Service) WaitForLockDeletion(c client.Client, path string) error {
+	// create a new keys API
+	kapi := client.NewKeysAPI(c)
+	// watch the key for deletion
+	for {
+		w := kapi.Watcher(path, nil)
+		resp, err := w.Next(context.Background())
+		if err != nil {
+			// the key was already removed, just return
+			if client.IsKeyNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		// wait for a delete action
+		if resp.Action == "delete" {
+			return nil
+		}
+	}
+}
+
+func (s *Service) lockContents() string {
+	host, err := os.Hostname()
+	if err != nil {
+		log.Printf("error fetching the hostname: %s", err)
+		host = "n/a"
+	}
+	return fmt.Sprintf("%s-%d", host, os.Getpid())
+}

--- a/legoetcd/service/service.go
+++ b/legoetcd/service/service.go
@@ -256,6 +256,8 @@ func (s *Service) createAccountIfNecessary(etcdClient client.Client) error {
 		if err := acc.LoadKey(etcdClient); err != nil {
 			return fmt.Errorf("was expecting the account to have a key: %s", err)
 		}
+
+		return nil
 	}
 	// we got a non-404 error, return it
 	return err

--- a/legoetcd/service/service.go
+++ b/legoetcd/service/service.go
@@ -163,7 +163,7 @@ func (s *Service) Run() error {
 					}
 				} else {
 					// lock was grabbed, renew the certificate
-					if err := cert.Renew(acmeClient, s.NoBundle); err != nil {
+					if err := cert.Renew(acmeClient, !s.NoBundle); err != nil {
 						log.Printf("error while renewing the certificate: %s", err)
 						goto nextChange
 					}
@@ -204,7 +204,7 @@ func (s *Service) generateCertificateIfNecessary(etcdClient client.Client, acmeC
 		defer s.Unlock(etcdClient, lockPath)
 		// create a new certificate for domains or csr.
 		var failures map[string]error
-		cert, failures = acmeClient.NewCert(s.domains, s.csrFile, s.NoBundle)
+		cert, failures = acmeClient.NewCert(s.domains, s.csrFile, !s.NoBundle)
 		if len(failures) > 0 {
 			for k, v := range failures {
 				log.Printf("[%s] Could not obtain certificates\n\t%s", k, v.Error())

--- a/legoetcd/service/service.go
+++ b/legoetcd/service/service.go
@@ -43,6 +43,7 @@ type Service struct {
 	NoBundle bool
 
 	acceptTOS   bool
+	acmeServer  string
 	csrFile     string
 	dns         string
 	domains     []string
@@ -56,12 +57,13 @@ type Service struct {
 // by setting the KeyType on the returned service. By default, the service will
 // generate a bundled certificate (containing the issuer certificate and your
 // certificate). To disable bundling, set `NoBundle` to true.
-func New(etcdConfig client.Config, email string, domains []string, csrFile string, acceptTOS, generatePEM bool, dns, webroot string) *Service {
+func New(etcdConfig client.Config, acmeServer, email string, domains []string, csrFile string, acceptTOS, generatePEM bool, dns, webroot string) *Service {
 	return &Service{
 		CertChan: make(chan *legoetcd.Cert),
 		KeyType:  acme.RSA2048,
 
 		acceptTOS:   acceptTOS,
+		acmeServer:  acmeServer,
 		csrFile:     csrFile,
 		dns:         dns,
 		domains:     domains,
@@ -73,7 +75,7 @@ func New(etcdConfig client.Config, email string, domains []string, csrFile strin
 }
 
 // Run starts the certificate loop
-func (s *Service) Run(etcdEndpoint []string, acmeServer string, stop chan struct{}) error {
+func (s *Service) Run(stop chan struct{}) error {
 	// create an etcd client
 	etcdClient, err := client.New(s.etcdConfig)
 	// create a new keys API
@@ -84,7 +86,7 @@ func (s *Service) Run(etcdEndpoint []string, acmeServer string, stop chan struct
 	}
 	// create a new ACME client
 	// TODO: httpAddr and tlsAddr support
-	acmeClient, err := legoetcd.New(etcdClient, acmeServer, s.email, s.KeyType, s.dns, s.webroot, "", "")
+	acmeClient, err := legoetcd.New(etcdClient, s.acmeServer, s.email, s.KeyType, s.dns, s.webroot, "", "")
 	if err != nil {
 		return fmt.Errorf("error creating a new ACME server: %s", err)
 	}

--- a/legoetcd/service/service.go
+++ b/legoetcd/service/service.go
@@ -102,7 +102,7 @@ func (s *Service) Run() error {
 	}
 	// watch the certificate on etcd, and send the certificate down the channel.
 	// initialize the certificate
-	cert, err = s.generateCertificateIfNecessary(etcdClient, acmeClient)
+	cert, err := s.generateCertificateIfNecessary(etcdClient, acmeClient)
 	if err != nil {
 		return err
 	}

--- a/legoetcd/service/service.go
+++ b/legoetcd/service/service.go
@@ -1,0 +1,240 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/coreos/etcd/client"
+	"github.com/kalbasit/lego-etcd/legoetcd"
+	"github.com/xenolf/lego/acme"
+)
+
+const (
+	accountLockKey = "/lego/accounts/%s/lock"
+	certLockKey    = "/lego/certificates/%s.lock"
+)
+
+var (
+	// ErrGeneratingCert is returned when there's a failure generating a new certificate.
+	ErrGeneratingCert = errors.New("an error occurred while generating the certificate, please check the log for more information")
+	// ErrTOSNotAccepted is returns if the acceptTOS was set to false and the account has never accepted the TOS.
+	ErrTOSNotAccepted = errors.New("Let's encrypt terms of service was not accepted")
+
+	minimumDurationForRenewal = 45 * 24 * time.Hour
+)
+
+// Service represents a lego-etcd service that is able to manage the
+// certificate for the given domains by generating certificates through Let's
+// encrypt, storing them in etcd and renew them as well. The service is fully
+// managed.
+type Service struct {
+	// CertChan is the channel where the service sends out the certificate at the
+	// retrieval and at the renewal time.
+	CertChan chan *legoetcd.Cert
+	// KeyType is the crypto type for the key, Supported: rsa2048, rsa4096,
+	// rsa8192, ec256, ec384.
+	KeyType acme.KeyType
+	// NoBundle disables bundling of the issuer certificate along with the
+	// domain's certificate.
+	NoBundle bool
+
+	acceptTOS   bool
+	csrFile     string
+	dns         string
+	domains     []string
+	email       string
+	etcdConfig  client.Config
+	generatePEM bool
+	webroot     string
+}
+
+// New returns a new service, the default keyType is RSA2048 but you may change
+// by setting the KeyType on the returned service. By default, the service will
+// generate a bundled certificate (containing the issuer certificate and your
+// certificate). To disable bundling, set `NoBundle` to true.
+func New(etcdConfig client.Config, email string, domains []string, csrFile string, acceptTOS, generatePEM bool, dns, webroot string) *Service {
+	return &Service{
+		CertChan: make(chan *legoetcd.Cert),
+		KeyType:  acme.RSA2048,
+
+		acceptTOS:   acceptTOS,
+		csrFile:     csrFile,
+		dns:         dns,
+		domains:     domains,
+		email:       email,
+		etcdConfig:  etcdConfig,
+		generatePEM: generatePEM,
+		webroot:     webroot,
+	}
+}
+
+// Run starts the certificate loop
+func (s *Service) Run(etcdEndpoint []string, acmeServer string, stop chan struct{}) error {
+	// create an etcd client
+	etcdClient, err := client.New(s.etcdConfig)
+	// create a new keys API
+	kapi := client.NewKeysAPI(etcdClient)
+	// initialize the account
+	if err := s.createAccountIfNecessary(etcdClient); err != nil {
+		return err
+	}
+	// create a new ACME client
+	// TODO: httpAddr and tlsAddr support
+	acmeClient, err := legoetcd.New(etcdClient, acmeServer, s.email, s.KeyType, s.dns, s.webroot, "", "")
+	if err != nil {
+		return fmt.Errorf("error creating a new ACME server: %s", err)
+	}
+	// register the account and accept tos
+	if err := acmeClient.RegisterAccount(s.acceptTOS); err != nil {
+		if err == legoetcd.ErrMustAcceptTOS {
+			return ErrTOSNotAccepted
+		}
+		return fmt.Errorf("error registering the account: %s", err)
+	}
+	// watch the certificate on etcd, and send the certificate down the channel.
+	var cert *legoetcd.Cert
+	go func() {
+		w := kapi.Watcher(cert.CertPath(), nil)
+		for {
+			done := make(chan struct{})
+			ctx, cancelFunc := context.WithCancel(context.Background())
+			go func(done chan struct{}) {
+				// block until either a stop which cancels the context or a stop event
+				// which is sent after the current next unblocks.
+				select {
+				case <-stop:
+					cancelFunc()
+				case <-done:
+				}
+			}(done)
+			resp, err := w.Next(ctx)
+			close(done)
+			cancelFunc()
+			if err != nil {
+				log.Printf("received an error fetching the next change to the certificate %q: %s", cert.CertPath(), err)
+			}
+			if resp.Action != "get" && resp.Action != "delete" {
+				// sleep for one second to allow whoever updating to finish up with the
+				// key as well.
+				if err := cert.Reload(); err != nil {
+					log.Printf("error reloading the certificate: %s", err)
+				} else {
+					s.CertChan <- cert
+				}
+			}
+		}
+	}()
+	// initialize the certificate
+	cert, err = s.generateCertificateIfNecessary(etcdClient, acmeClient)
+	// start the update loop
+	t := time.NewTicker(12 * time.Hour)
+	for {
+		select {
+		case <-t.C:
+			// do we need to renew the certificate?
+			exp, err := cert.ExpiresIn()
+			if err != nil {
+				log.Printf("was not able to query the certificate expiration date: %s", err)
+				goto nextChange
+			}
+			if exp > minimumDurationForRenewal {
+				// TODO: must LOCK here.
+				// renew the certificate
+				if err := cert.Renew(s.NoBundle); err != nil {
+					return err
+				}
+				// save the certificate
+				if err := cert.Save(s.generatePEM); err != nil {
+					return err
+				}
+			}
+		case <-stop:
+			return nil
+		}
+	nextChange:
+		// this is the end of for, so the loop will start again.
+	}
+}
+
+func (s *Service) generateCertificateIfNecessary(etcdClient client.Client, acmeClient *legoetcd.Client) (*legoetcd.Cert, error) {
+	// try loading the certificate
+	cert, err := acmeClient.LoadCert(s.domains)
+	if err == nil {
+		return cert, nil
+	}
+	// we do not have a certificate, create a lock and create it - or wait for
+	// another process to do so.
+	lockPath := fmt.Sprintf(certLockKey, s.domains[0])
+	// try to grab a lock
+	if err := s.Lock(etcdClient, lockPath); err != nil {
+		if err == ErrLockExists {
+			// someone else grabbed the key, wait for it to be unlocked
+			if err := s.WaitForLockDeletion(etcdClient, lockPath); err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		// lock was grabbed, create the new account.
+		defer s.Unlock(etcdClient, lockPath)
+		// create a new certificate for domains or csr.
+		cert, failures := acmeClient.NewCert(s.domains, s.csrFile, s.NoBundle)
+		if len(failures) > 0 {
+			for k, v := range failures {
+				log.Printf("[%s] Could not obtain certificates\n\t%s", k, v.Error())
+			}
+			return nil, ErrGeneratingCert
+		}
+		// save the certificate
+		if err := cert.Save(s.generatePEM); err != nil {
+			return nil, fmt.Errorf("error saving the certificate: %s", err)
+		}
+	}
+	// finally make sure we can load the cert and return it
+	if err := cert.Reload(); err != nil {
+		return nil, fmt.Errorf("was expecting the certificate to be saved: %s", err)
+	}
+	return cert, nil
+}
+
+func (s *Service) createAccountIfNecessary(etcdClient client.Client) error {
+	// do we have an account?
+	acc := legoetcd.NewAccount(s.email)
+	err := acc.Load(etcdClient)
+	if err == nil {
+		// ok we have an account, short-circuit out of this func
+		return nil
+	}
+	// we got an error, is it a not-found error (means account does not exist)?
+	if client.IsKeyNotFound(err) {
+		// we do not have an account, create a lock and create it - or wait for
+		// another process to do so.
+		lockPath := fmt.Sprintf(accountLockKey, s.email)
+		if err := s.Lock(etcdClient, lockPath); err != nil {
+			if err == ErrLockExists {
+				// someone else grabbed the key, wait for it to be unlocked
+				if err := s.WaitForLockDeletion(etcdClient, lockPath); err != nil {
+					return err
+				}
+			}
+		} else {
+			// lock was grabbed, create the new account.
+			defer s.Unlock(etcdClient, lockPath)
+			if err := acc.GenerateKey(); err != nil {
+				return err
+			}
+			if err := acc.Save(etcdClient); err != nil {
+				return err
+			}
+		}
+		// finally make sure we can load the account (we just need the key actually).
+		if err := acc.LoadKey(etcdClient); err != nil {
+			return fmt.Errorf("was expecting the account to have a key: %s", err)
+		}
+	}
+	// we got a non-404 error, return it
+	return err
+}

--- a/legoetcd/service/service.go
+++ b/legoetcd/service/service.go
@@ -148,17 +148,20 @@ func (s *Service) Run(etcdEndpoint []string, acmeServer string, stop chan struct
 					if err == ErrLockExists {
 						// someone else grabbed the lock, wait for it to be unlocked
 						if err := s.WaitForLockDeletion(etcdClient, lockPath); err != nil {
-							return nil, err
+							log.Printf("error while waiting for the lock to be unlocked: %s", err)
+							goto nextChange
 						}
 					}
 				} else {
 					// lock was grabbed, renew the certificate
 					if err := cert.Renew(s.NoBundle); err != nil {
-						return err
+						log.Printf("error while renewing the certificate: %s", err)
+						goto nextChange
 					}
 					// save the certificate
 					if err := cert.Save(s.generatePEM); err != nil {
-						return err
+						log.Printf("error saving the certificate: %s", err)
+						goto nextChange
 					}
 				}
 			}

--- a/legoetcd/service/service.go
+++ b/legoetcd/service/service.go
@@ -203,7 +203,8 @@ func (s *Service) generateCertificateIfNecessary(etcdClient client.Client, acmeC
 		// lock was grabbed, create the new account.
 		defer s.Unlock(etcdClient, lockPath)
 		// create a new certificate for domains or csr.
-		cert, failures := acmeClient.NewCert(s.domains, s.csrFile, s.NoBundle)
+		var failures map[string]error
+		cert, failures = acmeClient.NewCert(s.domains, s.csrFile, s.NoBundle)
 		if len(failures) > 0 {
 			for k, v := range failures {
 				log.Printf("[%s] Could not obtain certificates\n\t%s", k, v.Error())

--- a/legoetcd/setup.go
+++ b/legoetcd/setup.go
@@ -26,11 +26,11 @@ var (
 	ErrAddressInvalid = errors.New("the address should be host:port")
 )
 
-func (c *Client) setupAccount(email string) error {
+func (c *Client) setupAccount(ec client.Client, email string) error {
 	// create a new account
 	c.Account = NewAccount(email)
 	// try loading from etcd
-	if err := c.Account.LoadKey(c.ETCD); err != nil {
+	if err := c.Account.LoadKey(ec); err != nil {
 		if client.IsKeyNotFound(err) {
 			// The account never existed, create one
 			c.Account.GenerateKey()
@@ -48,11 +48,11 @@ func (c *Client) setupChallenge(dns, webRoot, httpAddr, tlsAddr string) error {
 			return err
 		}
 
-		c.ACME.SetChallengeProvider(acme.HTTP01, provider)
+		c.Client.SetChallengeProvider(acme.HTTP01, provider)
 
 		// --webroot=foo indicates that the user specifically want to do a HTTP challenge
 		// infer that the user also wants to exclude all other challenges
-		c.ACME.ExcludeChallenges([]acme.Challenge{acme.DNS01, acme.TLSSNI01})
+		c.Client.ExcludeChallenges([]acme.Challenge{acme.DNS01, acme.TLSSNI01})
 	}
 
 	// setup HTTP port
@@ -61,7 +61,7 @@ func (c *Client) setupChallenge(dns, webRoot, httpAddr, tlsAddr string) error {
 			return ErrAddressInvalid
 		}
 
-		c.ACME.SetHTTPAddress(httpAddr)
+		c.Client.SetHTTPAddress(httpAddr)
 	}
 
 	// setup TLS port
@@ -70,7 +70,7 @@ func (c *Client) setupChallenge(dns, webRoot, httpAddr, tlsAddr string) error {
 			return ErrAddressInvalid
 		}
 
-		c.ACME.SetTLSAddress(tlsAddr)
+		c.Client.SetTLSAddress(tlsAddr)
 	}
 
 	if dns != "" {
@@ -106,11 +106,11 @@ func (c *Client) setupChallenge(dns, webRoot, httpAddr, tlsAddr string) error {
 		if err != nil {
 			return fmt.Errorf("error setting up the DNS provider: %s", err)
 		}
-		c.ACME.SetChallengeProvider(acme.DNS01, provider)
+		c.Client.SetChallengeProvider(acme.DNS01, provider)
 
 		// --dns=foo indicates that the user specifically want to do a DNS challenge
 		// infer that the user also wants to exclude all other challenges
-		c.ACME.ExcludeChallenges([]acme.Challenge{acme.HTTP01, acme.TLSSNI01})
+		c.Client.ExcludeChallenges([]acme.Challenge{acme.HTTP01, acme.TLSSNI01})
 	}
 
 	return nil

--- a/vendor/github.com/coreos/etcd/pkg/pathutil/path.go
+++ b/vendor/github.com/coreos/etcd/pkg/pathutil/path.go
@@ -1,0 +1,31 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package pathutil implements utility functions for handling slash-separated
+// paths.
+package pathutil
+
+import "path"
+
+// CanonicalURLPath returns the canonical url path for p, which follows the rules:
+// 1. the path always starts with "/"
+// 2. replace multiple slashes with a single slash
+// 3. replace each '.' '..' path name element with equivalent one
+// 4. keep the trailing slash
+// The function is borrowed from stdlib http.cleanPath in server.go.
+func CanonicalURLPath(p string) string {
+	if p == "" {
+		return "/"
+	}
+	if p[0] != '/' {
+		p = "/" + p
+	}
+	np := path.Clean(p)
+	// path.Clean removes trailing slash except for root,
+	// put the trailing slash back if necessary.
+	if p[len(p)-1] == '/' && np != "/" {
+		np += "/"
+	}
+	return np
+}

--- a/vendor/github.com/coreos/etcd/pkg/types/doc.go
+++ b/vendor/github.com/coreos/etcd/pkg/types/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2015 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package types declares various data types and implements type-checking
+// functions.
+package types

--- a/vendor/github.com/coreos/etcd/pkg/types/id.go
+++ b/vendor/github.com/coreos/etcd/pkg/types/id.go
@@ -1,0 +1,41 @@
+// Copyright 2015 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"strconv"
+)
+
+// ID represents a generic identifier which is canonically
+// stored as a uint64 but is typically represented as a
+// base-16 string for input/output
+type ID uint64
+
+func (i ID) String() string {
+	return strconv.FormatUint(uint64(i), 16)
+}
+
+// IDFromString attempts to create an ID from a base-16 string.
+func IDFromString(s string) (ID, error) {
+	i, err := strconv.ParseUint(s, 16, 64)
+	return ID(i), err
+}
+
+// IDSlice implements the sort interface
+type IDSlice []ID
+
+func (p IDSlice) Len() int           { return len(p) }
+func (p IDSlice) Less(i, j int) bool { return uint64(p[i]) < uint64(p[j]) }
+func (p IDSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }

--- a/vendor/github.com/coreos/etcd/pkg/types/set.go
+++ b/vendor/github.com/coreos/etcd/pkg/types/set.go
@@ -1,0 +1,178 @@
+// Copyright 2015 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"sort"
+	"sync"
+)
+
+type Set interface {
+	Add(string)
+	Remove(string)
+	Contains(string) bool
+	Equals(Set) bool
+	Length() int
+	Values() []string
+	Copy() Set
+	Sub(Set) Set
+}
+
+func NewUnsafeSet(values ...string) *unsafeSet {
+	set := &unsafeSet{make(map[string]struct{})}
+	for _, v := range values {
+		set.Add(v)
+	}
+	return set
+}
+
+func NewThreadsafeSet(values ...string) *tsafeSet {
+	us := NewUnsafeSet(values...)
+	return &tsafeSet{us, sync.RWMutex{}}
+}
+
+type unsafeSet struct {
+	d map[string]struct{}
+}
+
+// Add adds a new value to the set (no-op if the value is already present)
+func (us *unsafeSet) Add(value string) {
+	us.d[value] = struct{}{}
+}
+
+// Remove removes the given value from the set
+func (us *unsafeSet) Remove(value string) {
+	delete(us.d, value)
+}
+
+// Contains returns whether the set contains the given value
+func (us *unsafeSet) Contains(value string) (exists bool) {
+	_, exists = us.d[value]
+	return
+}
+
+// ContainsAll returns whether the set contains all given values
+func (us *unsafeSet) ContainsAll(values []string) bool {
+	for _, s := range values {
+		if !us.Contains(s) {
+			return false
+		}
+	}
+	return true
+}
+
+// Equals returns whether the contents of two sets are identical
+func (us *unsafeSet) Equals(other Set) bool {
+	v1 := sort.StringSlice(us.Values())
+	v2 := sort.StringSlice(other.Values())
+	v1.Sort()
+	v2.Sort()
+	return reflect.DeepEqual(v1, v2)
+}
+
+// Length returns the number of elements in the set
+func (us *unsafeSet) Length() int {
+	return len(us.d)
+}
+
+// Values returns the values of the Set in an unspecified order.
+func (us *unsafeSet) Values() (values []string) {
+	values = make([]string, 0)
+	for val := range us.d {
+		values = append(values, val)
+	}
+	return
+}
+
+// Copy creates a new Set containing the values of the first
+func (us *unsafeSet) Copy() Set {
+	cp := NewUnsafeSet()
+	for val := range us.d {
+		cp.Add(val)
+	}
+
+	return cp
+}
+
+// Sub removes all elements in other from the set
+func (us *unsafeSet) Sub(other Set) Set {
+	oValues := other.Values()
+	result := us.Copy().(*unsafeSet)
+
+	for _, val := range oValues {
+		if _, ok := result.d[val]; !ok {
+			continue
+		}
+		delete(result.d, val)
+	}
+
+	return result
+}
+
+type tsafeSet struct {
+	us *unsafeSet
+	m  sync.RWMutex
+}
+
+func (ts *tsafeSet) Add(value string) {
+	ts.m.Lock()
+	defer ts.m.Unlock()
+	ts.us.Add(value)
+}
+
+func (ts *tsafeSet) Remove(value string) {
+	ts.m.Lock()
+	defer ts.m.Unlock()
+	ts.us.Remove(value)
+}
+
+func (ts *tsafeSet) Contains(value string) (exists bool) {
+	ts.m.RLock()
+	defer ts.m.RUnlock()
+	return ts.us.Contains(value)
+}
+
+func (ts *tsafeSet) Equals(other Set) bool {
+	ts.m.RLock()
+	defer ts.m.RUnlock()
+	return ts.us.Equals(other)
+}
+
+func (ts *tsafeSet) Length() int {
+	ts.m.RLock()
+	defer ts.m.RUnlock()
+	return ts.us.Length()
+}
+
+func (ts *tsafeSet) Values() (values []string) {
+	ts.m.RLock()
+	defer ts.m.RUnlock()
+	return ts.us.Values()
+}
+
+func (ts *tsafeSet) Copy() Set {
+	ts.m.RLock()
+	defer ts.m.RUnlock()
+	usResult := ts.us.Copy().(*unsafeSet)
+	return &tsafeSet{usResult, sync.RWMutex{}}
+}
+
+func (ts *tsafeSet) Sub(other Set) Set {
+	ts.m.RLock()
+	defer ts.m.RUnlock()
+	usResult := ts.us.Sub(other).(*unsafeSet)
+	return &tsafeSet{usResult, sync.RWMutex{}}
+}

--- a/vendor/github.com/coreos/etcd/pkg/types/slice.go
+++ b/vendor/github.com/coreos/etcd/pkg/types/slice.go
@@ -1,0 +1,22 @@
+// Copyright 2015 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+// Uint64Slice implements sort interface
+type Uint64Slice []uint64
+
+func (p Uint64Slice) Len() int           { return len(p) }
+func (p Uint64Slice) Less(i, j int) bool { return p[i] < p[j] }
+func (p Uint64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }

--- a/vendor/github.com/coreos/etcd/pkg/types/urls.go
+++ b/vendor/github.com/coreos/etcd/pkg/types/urls.go
@@ -1,0 +1,82 @@
+// Copyright 2015 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+type URLs []url.URL
+
+func NewURLs(strs []string) (URLs, error) {
+	all := make([]url.URL, len(strs))
+	if len(all) == 0 {
+		return nil, errors.New("no valid URLs given")
+	}
+	for i, in := range strs {
+		in = strings.TrimSpace(in)
+		u, err := url.Parse(in)
+		if err != nil {
+			return nil, err
+		}
+		if u.Scheme != "http" && u.Scheme != "https" && u.Scheme != "unix" && u.Scheme != "unixs" {
+			return nil, fmt.Errorf("URL scheme must be http, https, unix, or unixs: %s", in)
+		}
+		if _, _, err := net.SplitHostPort(u.Host); err != nil {
+			return nil, fmt.Errorf(`URL address does not have the form "host:port": %s`, in)
+		}
+		if u.Path != "" {
+			return nil, fmt.Errorf("URL must not contain a path: %s", in)
+		}
+		all[i] = *u
+	}
+	us := URLs(all)
+	us.Sort()
+
+	return us, nil
+}
+
+func MustNewURLs(strs []string) URLs {
+	urls, err := NewURLs(strs)
+	if err != nil {
+		panic(err)
+	}
+	return urls
+}
+
+func (us URLs) String() string {
+	return strings.Join(us.StringSlice(), ",")
+}
+
+func (us *URLs) Sort() {
+	sort.Sort(us)
+}
+func (us URLs) Len() int           { return len(us) }
+func (us URLs) Less(i, j int) bool { return us[i].String() < us[j].String() }
+func (us URLs) Swap(i, j int)      { us[i], us[j] = us[j], us[i] }
+
+func (us URLs) StringSlice() []string {
+	out := make([]string, len(us))
+	for i := range us {
+		out[i] = us[i].String()
+	}
+
+	return out
+}

--- a/vendor/github.com/coreos/etcd/pkg/types/urlsmap.go
+++ b/vendor/github.com/coreos/etcd/pkg/types/urlsmap.go
@@ -1,0 +1,107 @@
+// Copyright 2015 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// URLsMap is a map from a name to its URLs.
+type URLsMap map[string]URLs
+
+// NewURLsMap returns a URLsMap instantiated from the given string,
+// which consists of discovery-formatted names-to-URLs, like:
+// mach0=http://1.1.1.1:2380,mach0=http://2.2.2.2::2380,mach1=http://3.3.3.3:2380,mach2=http://4.4.4.4:2380
+func NewURLsMap(s string) (URLsMap, error) {
+	m := parse(s)
+
+	cl := URLsMap{}
+	for name, urls := range m {
+		us, err := NewURLs(urls)
+		if err != nil {
+			return nil, err
+		}
+		cl[name] = us
+	}
+	return cl, nil
+}
+
+// NewURLsMapFromStringMap takes a map of strings and returns a URLsMap. The
+// string values in the map can be multiple values separated by the sep string.
+func NewURLsMapFromStringMap(m map[string]string, sep string) (URLsMap, error) {
+	var err error
+	um := URLsMap{}
+	for k, v := range m {
+		um[k], err = NewURLs(strings.Split(v, sep))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return um, nil
+}
+
+// String turns URLsMap into discovery-formatted name-to-URLs sorted by name.
+func (c URLsMap) String() string {
+	var pairs []string
+	for name, urls := range c {
+		for _, url := range urls {
+			pairs = append(pairs, fmt.Sprintf("%s=%s", name, url.String()))
+		}
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, ",")
+}
+
+// URLs returns a list of all URLs.
+// The returned list is sorted in ascending lexicographical order.
+func (c URLsMap) URLs() []string {
+	var urls []string
+	for _, us := range c {
+		for _, u := range us {
+			urls = append(urls, u.String())
+		}
+	}
+	sort.Strings(urls)
+	return urls
+}
+
+// Len returns the size of URLsMap.
+func (c URLsMap) Len() int {
+	return len(c)
+}
+
+// parse parses the given string and returns a map listing the values specified for each key.
+func parse(s string) map[string][]string {
+	m := make(map[string][]string)
+	for s != "" {
+		key := s
+		if i := strings.IndexAny(key, ","); i >= 0 {
+			key, s = key[:i], key[i+1:]
+		} else {
+			s = ""
+		}
+		if key == "" {
+			continue
+		}
+		value := ""
+		if i := strings.Index(key, "="); i >= 0 {
+			key, value = key[:i], key[i+1:]
+		}
+		m[key] = append(m[key], value)
+	}
+	return m
+}


### PR DESCRIPTION
The use-case of this service is to be used as library and deployed and scaled on a cluster with etcd servers accessible. When the applications boot up, they should load (or lock and then create) an account, then load (or lock and then create) a certificate. The lock is there to prevent multiple processes of the same application from creating or renewing the account/certificate at the same time.
